### PR TITLE
Adding an abstract class which is inherited by the UpdateProfilePicture file.

### DIFF
--- a/Sport Accessories/Sport Accessories/Services/AbstractProfilePicture.cs
+++ b/Sport Accessories/Sport Accessories/Services/AbstractProfilePicture.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Identity;
+using Sport_Accessories.Areas.Identity.Models;
+
+namespace Sport_Accessories.Services
+{
+    public abstract class AbstractProfilePicture
+    {
+
+        protected string[] _allowed_types = { "image/jpeg", "image/png",
+                                            "image/jpg", "image/gif" };
+
+        public abstract Task<bool> ChangeProfilePictureAsync(IFormFile profilePicture,
+                                                             User user);
+        
+    }
+}

--- a/Sport Accessories/Sport Accessories/Services/UpdateProfilePicture.cs
+++ b/Sport Accessories/Sport Accessories/Services/UpdateProfilePicture.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.AspNetCore.Identity;
+using Sport_Accessories.Areas.Identity.Models;
+
+namespace Sport_Accessories.Services
+{
+    public class UpdateProfilePicture : AbstractProfilePicture
+    {
+        private readonly UserManager<User> _userManager;
+        private readonly IWebHostEnvironment _webHostEnvironment;
+        public UpdateProfilePicture(UserManager<User> userManager,
+                                          IWebHostEnvironment webHostEnvironment)
+        {
+            this._userManager = userManager;
+            this._webHostEnvironment = webHostEnvironment;
+        }
+
+        public override async Task<bool> ChangeProfilePictureAsync(IFormFile profilePicture,
+                                                                    User user)
+        {
+            
+                if (!_allowed_types.Contains(profilePicture.ContentType))
+                {
+                    //invalid image format
+                    return false;
+                }
+
+                string file_name = Guid.NewGuid().ToString() +
+                                  Path.GetExtension(profilePicture.FileName);
+
+                string upload_path = Path.Combine(_webHostEnvironment.WebRootPath, "images");
+
+                string file_path = Path.Combine(upload_path, file_name);
+
+                using (var file_stream = new FileStream(file_path, FileMode.Create))
+                {
+                    await profilePicture.CopyToAsync(file_stream);
+                }
+                var oldPath = _webHostEnvironment.WebRootPath + $"/images/{user.FileName}";
+
+                //if file already exists - delete it
+                if(File.Exists(oldPath))
+                {
+                    File.Delete(oldPath);
+                }
+
+                user.UpdateFile(file_name);
+
+                await _userManager.UpdateAsync(user);
+
+                return true;
+        }
+    }
+}
+


### PR DESCRIPTION
In this commit, I added an abstract class which is inherited by the UpdateProfilePicture file. The target is to follow the DI principe instead of locking to the UpdateProfilePicture only. This abstract class can be extended and added more logic without the need to change something in the existing logic.